### PR TITLE
Make react a peerDependency.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -36,7 +36,7 @@
     "lint",
     "test"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "react": "^0.13.3"
   },
   "devDependencies": {
@@ -57,6 +57,7 @@
     "node-libs-browser": "^0.5.2",
     "node-sass": "^3.1.2",
     "opener": "^1.4.1",
+    "react": "^0.13.3",
     "react-hot-loader": "^1.2.7",
     "sass-loader": "^1.0.2",
     "style-loader": "^0.12.3",


### PR DESCRIPTION
@carlosvillu @danderu can you review this please?

Removing react as an npm dependency of the components and making it a [peerDependency](https://docs.npmjs.com/files/package.json#peerdependencies), will allow the main app to specify the react version that it wants to use. Meaning we don't get duplicate versions of react on the same application.

We should start using npm3, because older npm versions will automatically install the peerDependencies and that should not happen. The app should explicitly say in its package.json that it depends on react.
