### PR TITLE
No need to export the component within an object.

### DIFF
--- a/app/templates/docs/_index.jsx
+++ b/app/templates/docs/_index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {<%= pascal_name %>} from '../src';
+import <%= pascal_name %> from '../src';
 import './style.scss';
 import '../src/index.scss';
 

--- a/app/templates/src/_index.jsx
+++ b/app/templates/src/_index.jsx
@@ -1,3 +1,3 @@
 import <%= pascal_name %> from './<%= component_name %>';
 
-export default {<%= pascal_name %>};
+export default <%= pascal_name %>;


### PR DESCRIPTION
@carlosvillu @danderu can you review this please?

I want to import my components like this:
```js
import MyComponent from "@schibstedspain/my-component";
```

not like this
```js
import { MyComponent } from "@schibstedspain/my-component";
```

Given there's a rule of exporting only one component per file, this makes no sense.